### PR TITLE
Update for Beat Saber 1.36.0

### DIFF
--- a/DiTails/DiTails.csproj
+++ b/DiTails/DiTails.csproj
@@ -132,6 +132,10 @@
 			<HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="SongCore">
+			<HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 		<Reference Include="Zenject">
 			<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
 			<Private>False</Private>

--- a/DiTails/DiTails.csproj
+++ b/DiTails/DiTails.csproj
@@ -50,6 +50,10 @@
 		  	<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNet.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="DataModels">
+		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\DataModels.dll</HintPath>
+            <Private>False</Private>
+        </Reference>
 		<Reference Include="Hive.Versioning">
 			<HintPath>$(BeatSaberDir)\Libs\Hive.Versioning.dll</HintPath>
 			<Private>False</Private>
@@ -59,7 +63,7 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="PlatformUserModel">
-		  	<HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\PlatformUserModel.dll</HintPath>
+		  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\PlatformUserModel.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="SemVer">

--- a/DiTails/LevelDataService.cs
+++ b/DiTails/LevelDataService.cs
@@ -6,6 +6,7 @@ using SiraUtil.Zenject;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using SongCore.Utilities;
 using Zenject;
 
 namespace DiTails
@@ -31,13 +32,15 @@ namespace DiTails
 
         internal async Task<Beatmap?> GetBeatmap(IDifficultyBeatmap difficultyBeatmap, CancellationToken token)
         {
-            if (!difficultyBeatmap.level.levelID.Contains("custom_level_"))
+            var level = difficultyBeatmap.level;
+            if (level is CustomPreviewBeatmapLevel customLevel)
             {
-                return null;
+                var hash = Hashing.GetCustomLevelHash(customLevel);
+                var beatmap = await _beatSaver.BeatmapByHash(hash, token);
+                return beatmap ?? null;
             }
-            var hash = difficultyBeatmap.level.levelID.Replace("custom_level_", "");
-            var beatmap = await _beatSaver.BeatmapByHash(hash, token);
-            return beatmap ?? null;
+
+            return null;
         }
 
         internal async Task<Beatmap> Vote(Beatmap beatmap, bool upvote, CancellationToken token)

--- a/DiTails/Managers/DetailContextManager.cs
+++ b/DiTails/Managers/DetailContextManager.cs
@@ -14,7 +14,7 @@ namespace DiTails.Managers
         private readonly StandardLevelDetailViewController _standardLevelDetailViewController;
 
         internal event Action? BeatmapUnselected;
-        internal event Action<StandardLevelDetailViewController, IDifficultyBeatmap>? DetailMenuRequested;
+        internal event Action<StandardLevelDetailViewController, BeatmapLevel>? DetailMenuRequested;
 
         #region Initialization
 
@@ -50,7 +50,7 @@ namespace DiTails.Managers
 
         private void ArtworkImageClicked(PointerEventData pointerEventData)
         {
-            DetailMenuRequested?.Invoke(_standardLevelDetailViewController, _standardLevelDetailViewController.selectedDifficultyBeatmap);
+            DetailMenuRequested?.Invoke(_standardLevelDetailViewController, _standardLevelDetailViewController.beatmapLevel);
         }
 
         private void DetailViewDeactivated(bool removedFromHierarchy, bool screenSystemDisabling)

--- a/DiTails/UI/DetailViewHost.cs
+++ b/DiTails/UI/DetailViewHost.cs
@@ -15,6 +15,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using SongCore.Utilities;
 using TMPro;
 using UnityEngine;
 using Zenject;
@@ -258,7 +259,8 @@ namespace DiTails.UI
             await SiraUtil.Extras.Utilities.PauseChamp;
             if (_activeBeatmap != null)
             {
-                Hash = _activeBeatmap.level.levelID.Replace("custom_level_", "");
+                var level = _activeBeatmap.level;
+                Hash = level is CustomBeatmapLevel customLevel ? Hashing.GetCustomLevelHash(customLevel) : level.levelID;
             }
             parserParams?.EmitEvent("show-level-hash");
         }

--- a/DiTails/Utilities/Extensions.cs
+++ b/DiTails/Utilities/Extensions.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System;
+using SongCore.Utilities;
 using UnityEngine;
 
 namespace DiTails.Utilities
@@ -40,5 +41,16 @@ namespace DiTails.Utilities
             return upgradedMonoBehaviour;
         }
 
+        public static bool TryGetHash(this BeatmapLevel level, out string hash)
+        {
+            if (level.levelID.StartsWith("custom_level_"))
+            {
+                hash = Hashing.GetCustomLevelHash(level);
+                return true;
+            }
+
+            hash = "";
+            return false;
+        }
     }
 }

--- a/DiTails/manifest.json
+++ b/DiTails/manifest.json
@@ -5,12 +5,12 @@
   "author": "Auros",
   "version": "1.0.0",
   "description": "View extra details about a map!",
-  "gameVersion": "1.34.0",
+  "gameVersion": "1.36.0",
   "dependsOn": {
     "BSIPA": "^4.2.1",
     "SiraUtil": "^3.0.0",
     "BeatSaverSharp": "^3.0.1",
     "BeatSaberMarkupLanguage": "^1.4.1",
-    "SongCore": "^3.8.1"
+    "SongCore": "^3.13.0"
   }
 }

--- a/DiTails/manifest.json
+++ b/DiTails/manifest.json
@@ -10,6 +10,7 @@
     "BSIPA": "^4.2.1",
     "SiraUtil": "^3.0.0",
     "BeatSaverSharp": "^3.0.1",
-    "BeatSaberMarkupLanguage": "^1.4.1"
+    "BeatSaberMarkupLanguage": "^1.4.1",
+    "SongCore": "^3.8.1"
   }
 }


### PR DESCRIPTION
Included a minor fix on song hash by using SongCore. 
The original method is not always correct because the game will append directory names to the level ID for the levels with the same hash. This fix was committed before I made any changes for 1.36. I can make a separate PR if you prefer.

For the 1.36 update, I have also bumped the dependency versions so it will not load on older (<1.34.4) versions of the game. 
